### PR TITLE
Add IgnoreUnknownColumns to CsvFileDescription

### DIFF
--- a/LINQtoCSV.Tests/CsvContextReadTests.cs
+++ b/LINQtoCSV.Tests/CsvContextReadTests.cs
@@ -125,7 +125,7 @@ CCCCCCCC12.00012/23/08";
             CsvFileDescription fileDescription_namesUs = new CsvFileDescription
             {
                 SeparatorChar = ',',
-                IgnoreMissingColumns = true,
+                IgnoreUnknownColumns = true,
                 UseFieldIndexForReadingData = true,
                 FirstLineHasColumnNames = false,
                 EnforceCsvColumnAttribute = true, // default is false
@@ -162,7 +162,7 @@ CCCCCCCC12.00012/23/08";
             CsvFileDescription fileDescription_namesUs = new CsvFileDescription
             {
                 SeparatorChar = ',',
-                IgnoreMissingColumns = true,
+                IgnoreUnknownColumns = true,
                 UseOutputFormatForParsingCsvValue = true,
 
                 UseFieldIndexForReadingData = true,
@@ -330,6 +330,42 @@ and a quoted ""string"""
             // Act and Assert
 
             AssertRead(testInput, fileDescription_namesUs, expected);
+        }
+
+        [TestMethod()]
+        public void FileWithUnknownColumns_ShouldDiscardColumns() {
+            var description = new CsvFileDescription
+                {
+                    SeparatorChar = ',',
+                    FirstLineHasColumnNames = true,
+                    IgnoreUnknownColumns = true,
+                };
+            
+            //The following input has 5 columns: Id | Name | Last Name | Age | City. Only the Name, Last Name and Age will be read.
+            
+            string input =
+@"Id,Name,Last Name,Age,City
+1,John,Doe,15,Washington
+2,Jane,Doe,20,New York
+";
+            var expected = new[]
+                {
+                    new Person
+                        {
+                            Name = "John",
+                            LastName = "Doe",
+                            Age = 15
+                        },
+                    new Person
+                        {
+                            Name = "Jane",
+                            LastName = "Doe",
+                            Age = 20
+                        },
+                };
+
+            AssertRead(input, description, expected);
+
         }
     }
 }

--- a/LINQtoCSV.Tests/LINQtoCSV.Tests.csproj
+++ b/LINQtoCSV.Tests/LINQtoCSV.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="CsvContextWriteTests.cs" />
     <Compile Include="CsvContextReadTests.cs" />
     <Compile Include="IAssertable.cs" />
+    <Compile Include="Person.cs" />
     <Compile Include="ProductDataSpecificFieldIndex.cs" />
     <Compile Include="ProductData.cs" />
     <Compile Include="ProductData_DuplicateIndices.cs" />

--- a/LINQtoCSV.Tests/Person.cs
+++ b/LINQtoCSV.Tests/Person.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LINQtoCSV.Tests
+{
+    public class Person : IAssertable<Person> {
+        [CsvColumn(Name = "Name")]
+        public string Name { get; set; }
+        [CsvColumn(Name = "Last Name")]
+        public string LastName { get; set; }
+        [CsvColumn(Name = "Age")]
+        public int Age { get; set; }
+
+        public void AssertEqual(Person other) {
+            Assert.AreEqual(other.Name, Name);
+            Assert.AreEqual(other.LastName, LastName);
+            Assert.AreEqual(other.Age, Age);
+        }
+    }
+}

--- a/LINQtoCSV/CsvFileDescription.cs
+++ b/LINQtoCSV/CsvFileDescription.cs
@@ -87,10 +87,14 @@ namespace LINQtoCSV
         public Encoding TextEncoding { get; set; }
         public bool DetectEncodingFromByteOrderMarks { get; set; }
 
-        public bool IgnoreMissingColumns { get; set; }
         public bool UseFieldIndexForReadingData { get; set; }
         public bool UseOutputFormatForParsingCsvValue { get; set; }
         public bool IgnoreTrailingSeparatorChar { get; set; }
+        
+        /// <summary>
+        /// If set to true, wil read only the fields specified as attributes, and will discard other fields in the CSV file
+        /// </summary>
+        public bool IgnoreUnknownColumns { get; set; }
 
         // ---------------
 
@@ -107,6 +111,7 @@ namespace LINQtoCSV
             NoSeparatorChar = false;
             UseFieldIndexForReadingData = false;
             UseOutputFormatForParsingCsvValue = false;
+            IgnoreUnknownColumns = false;
         }
     }
 }

--- a/article.htm
+++ b/article.htm
@@ -465,7 +465,10 @@ You can then access each individual field within each data row:
 <li><a href="#NoSeparatorChar"><code>NoSeparatorChar</code></a> </li>
 
 <li><a href="#UseFieldIndexForReadingData"><code>UseFieldIndexForReadingData</code></a> </li>
-    <li><a href="#IgnoreTrailingSeparatorChar"><code>IgnoreTrailingSeparatorChar</code></a> </li>
+
+<li><a href="#IgnoreTrailingSeparatorChar"><code>IgnoreTrailingSeparatorChar</code></a> </li>
+
+<li><a href="#IgnoreUnknownColumns"><code>IgnoreUnknownColumns</code></a> </li>
 </ul>
 
 <h3><a id="SeparatorChar">SeparatorChar</a></h3>
@@ -837,6 +840,78 @@ Modifies the behaviour of the
 <p><code>column1;column2;column3;</code></p>
 
 <p>Though it's not a canonical representation of CSV file, <code>IgnoreTrailingSeparatorChar</code> property tells <code>Read</code> to ignore separator character at the end of the line.</p>
+
+<!-----------IgnoreUnknownColumns----------->
+<h3><a id="IgnoreUnknownColumns"></a>IgnoreUnknownColumns</h3>
+
+<table cellpadding="3">
+    <tbody>
+        <tr>
+            <td><strong>Type:</strong></td>
+
+            <td><code lang="cs">bool</code></td>
+        </tr>
+
+        <tr>
+            <td><strong>Default:</strong></td>
+
+            <td>false</td>
+        </tr>
+
+        <tr>
+            <td><strong>Applies to:</strong></td>
+
+            <td>Reading only</td>
+        </tr>
+    </tbody>
+</table>
+
+<h4>Example:</h4>
+
+There are cases where you don't need to read all the columns, but only a subset of them. Consider the following example of a CSV file containing a list of people:<br><br>
+
+<table cellspacing="0" cellpadding="5" border="1">
+    <tbody>
+        <tr>
+            <th>Id</th>
+            <th>Name</th>
+            <th>Last Name</th>
+            <th>Age</th>
+            <th>City</th>
+        </tr>
+        <tr>
+            <td>1</td>
+            <td>John</td>
+            <td>Doe</td>
+            <td>15</td>
+            <td>Washington</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td>Jane</td>
+            <td>Doe</td>
+            <td>20</td>
+            <td>New York</td>
+        </tr>
+    </tbody>
+</table>
+<br>
+Suppose you have the following class:
+<pre lang="cs">
+    class Person {
+        [CsvColumn(Name = "Name")]
+        public string Name { get ; set; }
+        [CsvColumn(Name = "Last Name")]
+        public string LastName { get; set; }
+        [CsvColumn(Name = "Age")]
+        public int Age { get; set; }
+    }
+</pre>
+If you set <pre lang="cs">fd.IgnoreTrailingSeparatorChar = true;</pre>
+
+then the fields <code>Id</code> and <code>City</code> will be ignored.
+
+<!---------------------------------------------->
 
 <h2>CsvColumn Attribute<a id="CsvColumn_Attribute"></a></h2>
 


### PR DESCRIPTION
Adds feature discussed in #9. 
- Modify `article.htm` to document the changes
- Add unit test to make sure the new functionality works
- Add ToString() method in `TypeFieldInfo` class for better debugging

**A few important things:**
- There was an existing (undocumented) `IgnoreMissingColumns` field, used mainly for `UseFieldIndexForReadingData`. It was renamed to `IgnoreUnknownColumns`, since the purpose of `IgnoreMissingColumns` is covered by `IgnoreUnknownColumns` now, to avoid having duplicate fields.
- The entire code probably needs to be refactored at some point in the future, so more unit tests will be required. If we keep adding properties to the `CsvFileDescription` class, the code might become kind of an spaguetti one.
