### PR TITLE
Add ability to skip lines

### DIFF
--- a/LINQtoCSV/CsvContext.cs
+++ b/LINQtoCSV/CsvContext.cs
@@ -125,6 +125,11 @@ namespace LINQtoCSV
 
                 stream.BaseStream.Seek(0, SeekOrigin.Begin);
             }
+            
+            for (int i = 0; i < fileDescription.LinesToSkip; i++)
+            {
+                stream.ReadLine();
+            }
 
             // ----------
 

--- a/LINQtoCSV/CsvFileDescription.cs
+++ b/LINQtoCSV/CsvFileDescription.cs
@@ -95,6 +95,8 @@ namespace LINQtoCSV
         /// If set to true, wil read only the fields specified as attributes, and will discard other fields in the CSV file
         /// </summary>
         public bool IgnoreUnknownColumns { get; set; }
+        
+        public int LinesToSkip { get; set; }
 
         // ---------------
 
@@ -112,6 +114,7 @@ namespace LINQtoCSV
             UseFieldIndexForReadingData = false;
             UseOutputFormatForParsingCsvValue = false;
             IgnoreUnknownColumns = false;
+            LinesToSkip = 0;
         }
     }
 }


### PR DESCRIPTION
Adds a `LinesToSkip` parameter to `CsvFileDescription` in order to skip extraneous lines at the beginning of a file or stream as proposed in #34 